### PR TITLE
Update nova_characters.php

### DIFF
--- a/nova/modules/core/controllers/nova_characters.php
+++ b/nova/modules/core/controllers/nova_characters.php
@@ -1908,14 +1908,14 @@ abstract class Nova_characters extends Nova_controller_admin {
 					$a->suffix
 				);
 				
+				$pos = $this->pos->get_position($a->position_1);
+				
 				if ($level == 1)
 				{
 					$cdept = $dept;
 				}
 				else
-				{
-					$pos = $this->pos->get_position($a->position_1);
-					
+				{					
 					if ($pos !== false and array_key_exists($pos->pos_dept, $data['characters']) === false)
 					{
 						$cdept = $this->dept->get_dept($pos->pos_dept, 'dept_parent');


### PR DESCRIPTION
Moved declaration of $pos outside of if/else because it is used further down for all access levels and was erroring when the user's level was 1.

This is a resolution for issue #240 
