### PR TITLE
Fix version number in update complete message

### DIFF
--- a/nova/modules/core/controllers/nova_update.php
+++ b/nova/modules/core/controllers/nova_update.php
@@ -454,7 +454,9 @@ abstract class Nova_update extends CI_Controller {
 				$data['label'] = array(
 					'text' => sprintf(
 						lang('upd_step2_success'),
-						$system_info['sys_version_major'].$system_info['sys_version_minor'].$system_info['sys_version_update']
+						$system_info['sys_version_major'],
+						$system_info['sys_version_minor'],
+						$system_info['sys_version_update']
 					),
 					'back' => lang('upd_step2_site')
 				);

--- a/nova/modules/core/language/english/install_lang.php
+++ b/nova/modules/core/language/english/install_lang.php
@@ -318,7 +318,7 @@ $lang['upd_step1_memory'] = "Your server doesn't have enough available memory to
  * Step 2
  */
 $lang['upd_step2_title'] = 'Step 2: Run Update';
-$lang['upd_step2_success'] = 'You have successfully updated Nova to version %s. You can continue using Nova as normal now. Remember to turn maintenance mode off from the Site Settings page so the rest of your users can use the site!';
+$lang['upd_step2_success'] = 'You have successfully updated Nova to version %u.%u.%u. You can continue using Nova as normal now. Remember to turn maintenance mode off from the Site Settings page so the rest of your users can use the site!';
 $lang['upd_step2_site'] = 'Back to Site';
 
 /*


### PR DESCRIPTION
Output on update to v2.3.0 was:

> You have successfully updated Nova to version 230. You can continue using Nova as normal now. Remember to turn maintenance mode off from the Site Settings page so the rest of your users can use the site!

I believe it should have been:

> You have successfully updated Nova to version 2.3.0. You can continue using Nova as normal now. Remember to turn maintenance mode off from the Site Settings page so the rest of your users can use the site!

This was because the system info versions were just concatenated:

``` php
$system_info['sys_version_major'].$system_info['sys_version_minor'].$system_info['sys_version_update']
```

Fix was to use `sprintf` with three parameterized values and formatting them all as `%u` given that all numbers in semantic versioning must be positive, and that the columns only support integers, not string suffixes.
