### PR TITLE
Avoid sql_mode STRICT_TRANS_TABLES during install

### DIFF
--- a/nova/modules/core/controllers/nova_install.php
+++ b/nova/modules/core/controllers/nova_install.php
@@ -1179,7 +1179,14 @@ abstract class Nova_install extends CI_Controller {
 			case 2:
 				// pull in the install data asset file
 				include_once MODPATH.'assets/install/data.php';
-				
+                
+				$originalModeQuery = $this->db->query('SELECT @@SESSION.sql_mode;');
+				if ($originalModeQuery->num_rows() > 0)
+				{
+					$originalMode = $originalModeQuery->first_row('array')['@@SESSION.sql_mode'];
+					$this->db->query('SET SESSION sql_mode = "";');
+				}
+                
 				$insert = array();
 				
 				foreach ($data as $value)
@@ -1202,6 +1209,11 @@ abstract class Nova_install extends CI_Controller {
 							$insert[] = $this->db->insert($value, $v);
 						}
 					}
+				}
+                
+				if (isset($originalMode))
+				{
+					$this->db->query('SET SESSION sql_mode = "'.$originalMode.'";');
 				}
 				
 				foreach ($insert as $key => $i)


### PR DESCRIPTION
As of MySQL 5.7.5, the default `sql_mode` includes `STRICT_TRANS_TABLES`. 

For instance, in MySQL 5.7, the default `sql_mode` is:

```
ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
```

Because a default value cannot be specified for `TEXTAREA` fields, when the install script runs, it spits back errors like:

> Field 'field_class' doesn't have a default value

This pull request implements a fix that reads the current SQL mode,  applies an empty SQL mode to run the install, and finally re-applies the current SQL mode for the rest of the session. While we could do some string transmuting to just strip out `STRICT_TRANS_TABLES`, it was simpler to just unset all the special modes since the install script doesn't rely on any of them.

This should resolve issues such as the one reported in this thread:
http://forums.anodyne-productions.com/viewtopic.php?f=60&t=3626&p=20801
