### PR TITLE
Remove modes that trigger strict SQL mode

### DIFF
--- a/nova/modules/core/libraries/Nova_controller_admin.php
+++ b/nova/modules/core/libraries/Nova_controller_admin.php
@@ -54,6 +54,8 @@ class Nova_controller_admin extends CI_Controller {
 		
 		$this->load->database();
 		$this->load->model('system_model', 'sys');
+        
+		$this->sys->prepare_database_session();
 		
 		// check to see if the system is installed
 		$installed = $this->sys->check_install_status();

--- a/nova/modules/core/libraries/Nova_controller_main.php
+++ b/nova/modules/core/libraries/Nova_controller_main.php
@@ -54,6 +54,8 @@ class Nova_controller_main extends CI_Controller {
 		
 		$this->load->database();
 		$this->load->model('system_model', 'sys');
+        
+		$this->sys->prepare_database_session();
 		
 		// check to see if the system is installed
 		$installed = $this->sys->check_install_status();

--- a/nova/modules/core/libraries/Nova_controller_wiki.php
+++ b/nova/modules/core/libraries/Nova_controller_wiki.php
@@ -49,6 +49,8 @@ class Nova_controller_wiki extends CI_Controller {
 		
 		$this->load->database();
 		$this->load->model('system_model', 'sys');
+        
+		$this->sys->prepare_database_session();
 		
 		// check to see if the system is installed
 		$installed = $this->sys->check_install_status();

--- a/nova/modules/core/models/nova_system_model.php
+++ b/nova/modules/core/models/nova_system_model.php
@@ -706,4 +706,29 @@ abstract class Nova_system_model extends CI_Model {
 			return false;
 		}
 	}
+    
+	public function prepare_database_session()
+	{
+		if ($this->db->dbdriver == 'mysql')
+		{
+			$modeQuery = $this->db->query('SELECT @@SESSION.sql_mode;');
+			if ($modeQuery->num_rows() > 0)
+			{
+				$modeSegs = explode(',', $modeQuery->first_row('array')['@@SESSION.sql_mode']);
+                
+				if (($idx = array_search('STRICT_TRANS_TABLES', $modeSegs)) !== false)
+				{
+					array_splice($modeSegs, $idx, 1);
+				}
+                
+				if (($idx = array_search('STRICT_ALL_TABLES', $modeSegs)) !== false)
+				{
+					array_splice($modeSegs, $idx, 1);
+				}
+                
+				$newMode = implode(',', $modeSegs);
+				$this->db->query('SET SESSION sql_mode = "'.$newMode.'";');
+			}
+		}
+	}
 }


### PR DESCRIPTION
Yesterday, I submitted a pull request #262 that unset all SQL modes for the installation routine. It was a bit brute force, but so long as the installation was the only place where it was necessary, it seemed a reasonable approach; however, I found some other places, like creating a new mission, that also fail when `STRICT_TRANS_TABLES` is a mode, so I closed that one and decided to work on a more generic fix.

To recap, the reason that this is an issue is that, as of MySQL 5.7.5, the default SQL mode includes `STRICT_TRANS_TABLES`. This mode, along with `STRICT_ALL_TABLES`, both [trigger Strict SQL mode](http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict). This causes errors across Nova in any place where it writes a row to a table without specifying a value for any `TEXTAREA` field in the table, because `TEXTAREA` cannot carry a default value in MySQL and, if strict SQL mode is in operation, it will not use `""` implicitly.

For reference, in MySQL 5.7, the default `sql_mode` is:

```
ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
```

And the errors it spits back are like:

> Field 'field_class' doesn't have a default value

This pull request implements a fix that:
1. Adds a new `prepare_database_session()` routine to the system model that, when `mysql` is the database driver, causes it to remove `STRICT_TRANS_TABLES` and `STRICT_ALL_TABLES` from the SQL mode for the database _session_.
2. Invokes the new `Nova_system_model->prepare_database_session()` routine from the main, wiki and admin base controllers.

This should resolve issues such as the one reported in this thread:
http://forums.anodyne-productions.com/viewtopic.php?f=60&t=3626&p=20801
