### PR TITLE
Site Ban Fixes

### DIFF
--- a/nova/modules/core/controllers/nova_site.php
+++ b/nova/modules/core/controllers/nova_site.php
@@ -31,6 +31,9 @@ abstract class Nova_site extends Nova_controller_admin {
 						$insert_array[$key] = $this->security->xss_clean($value);
 					}
 					
+					// pin to level 1 if no radio option was selected
+					($insert_array['ban_level'] < 1)? $insert_array['ban_level'] = 1 : '';
+					
 					// pop unnecessary items off the array
 					unset($insert_array['submit']);
 					
@@ -116,7 +119,12 @@ abstract class Nova_site extends Nova_controller_admin {
 				'id' => 'ban_email'),
 			'ip' => array(
 				'name' => 'ban_ip',
-				'id' => 'ban_ip')
+				'id' => 'ban_ip'),
+			'date' => array(
+				'name' => 'ban_date',
+				'id' => 'ban_date',
+				'type' => 'hidden',
+				'value' => now())
 		);
 		
 		// get the list of bans

--- a/nova/modules/core/views/_base/admin/pages/site_bans.php
+++ b/nova/modules/core/views/_base/admin/pages/site_bans.php
@@ -36,6 +36,7 @@
 			<kbd><?php echo $label['reason'];?></kbd>
 			<?php echo form_textarea($inputs['reason']);?>
 		</p>
+		<?php echo form_input($inputs['date']);?>
 		<p><?php echo form_button($buttons['add']);?></p>
 	<?php echo form_close();?>
 </div><br />


### PR DESCRIPTION
Pinning bans to level 1 when no level has been set (as the form has no validation to ensure that one of the radio buttons has been clicked)

Adding a hidden input to the add ban form to ensure that the ban_date is set.