### PR TITLE
Add User Account Self-Deletion

### DIFF
--- a/nova/modules/core/language/english/base_lang.php
+++ b/nova/modules/core/language/english/base_lang.php
@@ -567,6 +567,7 @@ $lang['login_error_incorrect'] = 'Either your username and/or password are incor
 $lang['login_instructions'] = 'Login with your email address and password below. If you have forgotten your password, you can reset your password using the link below and a new password will be emailed to you.';
 $lang['login_redirect'] = 'Login successful. Redirecting to Control Panel in <span id="countdown"></span>&nbsp;seconds...';
 $lang['logout_message'] = 'You have successfully logged out. You can %s or proceed to the %s. You will be redirected in <span id="countdown"></span>&nbsp;seconds.';
+$lang['logout_account_delete_message'] = 'Your account and personal information have been deleted, and you have thus been logged out. You will be redirected in <span id="countdown"></span>&nbsp;seconds.';
 $lang['login_questions_selectone'] = 'Please select your security question';
 $lang['login_reset_message'] = "Please provide your email address, security question, and answer to reset your password. Once you have reset your password, your new one will be emailed to you and you will be prompted to change it the next time you log in.";
 $lang['login_message'] = 'Login successful. Redirecting to %s in <span id="countdown"></span>&nbsp;seconds...';

--- a/nova/modules/core/language/english/text_lang.php
+++ b/nova/modules/core/language/english/text_lang.php
@@ -139,6 +139,8 @@ $lang['text_skins_global'] = "These options control the skins for the site when 
 
 $lang['text_skins_user'] = "These options control the skins for the site when you are logged in. If you want to change the skin that visitors who are not logged in see, you will need to use the <a href='%s'>Site Settings</a> page.";
 
+$lang['text_user_del_confirm'] = "Are you sure you wish to delete your user account and all personal information associated with it? This action is permanent and cannot be undone!";
+
 /*
 |---------------------------------------------------------------
 | INFORMATIONAL MESSAGES

--- a/nova/modules/core/views/_base/admin/pages/user_account.php
+++ b/nova/modules/core/views/_base/admin/pages/user_account.php
@@ -10,6 +10,10 @@
 
 <p><?php echo link_to_if($level == 2, 'user/characterlink/'. $inputs['id'], img($images['user']) .' '. $label['characters'], array('class' => 'bold image'));?></p>
 
+<?php if ($my_user):?>
+	<p><?php echo anchor('user/delete', img($images['delete']) .' '. $label['delete'], array('class' => 'bold image'));?></p>
+<?php endif;?>
+
 <?php if ($level == 2 and ! $my_user):?>
 	<p>
 		<kbd><?php echo $label['reset_password'];?></kbd>

--- a/nova/modules/core/views/_base/admin/pages/user_delete.php
+++ b/nova/modules/core/views/_base/admin/pages/user_delete.php
@@ -1,0 +1,11 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');?>
+
+<?php echo text_output($header, 'h1', 'page-head');?>
+
+<?php echo form_open('user/delete');?>
+
+<?php echo text_output($labels['confirm'], 'p');?>
+
+<p><?php echo form_button($buttons['confirm']);?></p>
+
+<?php echo form_close();?>


### PR DESCRIPTION
> The information contained within this pull request and the communications with Anodyne Productions and/or Bravo Fleet, including their agents and/or representatives, on this topic ("Communication") were prepared for informational purposes only. The Communication is not intended to be and should not be considered legal advice. The Communication is provided only as general information and may be incomplete and/or not reflect the most current legal developments. None of the Communication is intended to constitute an attorney-client relationship. You should not act upon any of this Communication without consulting professional legal counsel.

This pull request adds the ability for users to delete their own accounts. This pull request is submitted in order to support compliance with the **[Easy Withdrawal of Permission](https://forum.bravofleet.com/forum/announcements/bfa-announcements/30974-addressing-internet-privacy)** aspect of the GDPR.

A new link appears within your own account page (not when you view other accounts):

![screen shot 2018-05-07 at 1 44 05 pm](https://user-images.githubusercontent.com/2497540/39726287-7812563a-5203-11e8-8292-63e17827cd32.png)

When followed, a new page confirms the user's intent to delete their account:

![screen shot 2018-05-07 at 2 32 09 pm](https://user-images.githubusercontent.com/2497540/39726304-83c2fd54-5203-11e8-9941-21a792194c94.png)

And then their user account is deleted, their characters orphaned, and they are logged out and sent back to the home page:

![screen shot 2018-05-07 at 2 32 16 pm](https://user-images.githubusercontent.com/2497540/39726318-8a06dabe-5203-11e8-8d54-d9c56413cd8f.png)

@agentphoenix I'm sorry I couldn't get my tabs settings to match yours exactly.