### PR TITLE
Adjust HTML semantics and label of the character bio form

### DIFF
--- a/nova/modules/core/controllers/nova_characters.php
+++ b/nova/modules/core/controllers/nova_characters.php
@@ -1387,6 +1387,7 @@ abstract class Nova_characters extends Nova_controller_admin {
 		
 		$data['label'] = array(
 			'character' => ucfirst(lang('global_character')),
+			'assignment' => ucfirst(lang('assignment')),
 			'fname' => ucwords(lang('order_first') .' '. lang('labels_name')),
 			'images' => ucfirst(lang('labels_images')),
 			'info' => ucfirst(lang('labels_info')),

--- a/nova/modules/core/views/_base/admin/pages/characters_bio.php
+++ b/nova/modules/core/views/_base/admin/pages/characters_bio.php
@@ -64,7 +64,12 @@
 				<p>
 					<kbd><?php echo $label['suffix'];?></kbd>
 					<?php echo form_input($inputs['suffix']);?>
-				</p><br />
+				</p>
+			</div>
+			
+			<?php echo text_output($label['assignment'], 'h3', 'page-subhead');?>
+		
+			<div class="indent-left">
 				
 				<?php if ($level >= 2): ?>
 					<?php if (($level == 2 and $inputs['crew_type'] == 'npc') or $level == 3): ?>
@@ -109,9 +114,8 @@
 						<?php echo text_output($inputs['rank_name'], 'span', 'fontSmall gray');?>
 					</p>
 				<?php endif;?>
-				
-				<br /><?php echo form_button($button['submit']);?>
 			</div>
+			<?php echo form_button($button['submit']);?>
 		</div>
 		
 		<div id="two">


### PR DESCRIPTION
This pull request makes two modifications:

1. It adds a heading above the position and rank.
2. It moves the `Submit` button out of the fields div since it's not a field.

These are both stylistic preferences, and no worries if you don't want them, but I thought I'd send a PR for it since I use this change on my branch of Nova.

This makes the first tab of the character bio page look like:

<img width="887" alt="screen shot 2018-08-28 at 1 04 04 pm" src="https://user-images.githubusercontent.com/2497540/44747805-e492bf80-aac2-11e8-9736-c652f1ab005e.png">