### PR TITLE
Use same margin top/bottom as p tag for ul/ol in wiki

### DIFF
--- a/nova/modules/assets/include_head_wiki.php
+++ b/nova/modules/assets/include_head_wiki.php
@@ -31,7 +31,7 @@ $uiTheme = ( ! is_file(APPPATH .'views/'.$current_skin.'/wiki/css/jquery.ui.them
 			@import url("<?php echo $modFolder.'assets/js/markitup/skins/simple/style.css';?>");
 			@import url("<?php echo $modFolder.'assets/js/markitup/sets/'. $parse .'/style.css';?>");
 			
-			ul, ol { margin: 1em; padding: .5em; }
+			ul, ol { margin: 0 10px 10px 10px; padding: 0 0 0 10px; }
 			ul li, ol li { margin: 2px; }
 			ul { list-style: disc; }
 			ol { list-style: decimal; }


### PR DESCRIPTION
The main reason for this pull request is that `ul` and `ol` inside of the wiki look messy in that they have a tremendous amount of space before them that's inconsistent with other levels. 

Looking at the `p` tag, which is commonly used on either side of a list, we see in the base theme that it has a `margin-bottom: 10px` and no `margin-top` at all. This pull request brings the `ul` and `ol` in line with this.