### PR TITLE
Use text_output for single mission page description format

### DIFF
--- a/nova/modules/core/views/_base/admin/pages/manage_missions.php
+++ b/nova/modules/core/views/_base/admin/pages/manage_missions.php
@@ -27,7 +27,7 @@
 							<strong class="fontMedium"><?php echo $i['title'];?></strong><br />
 							<span class="fontSmall gray">
 								<?php echo text_output($label['posts'], 'strong') . $i['posts'];?><br />
-								<?php echo $i['desc'];?>
+								<?php echo text_output($i['desc']);?>
 							</span>
 						</td>
 						<td class="col_100 align_right">

--- a/nova/modules/core/views/_base/main/pages/sim_missions_one.php
+++ b/nova/modules/core/views/_base/main/pages/sim_missions_one.php
@@ -45,7 +45,7 @@
 				<tr>
 					<td class="cell-label"><?php echo $label['desc'];?></td>
 					<td class="cell-spacer"></td>
-					<td><?php echo $basic['desc'];?></td>
+					<td><?php echo text_output($basic['desc']);?></td>
 				</tr>
 				<?php if (is_array($basic['group'])): ?>
 					<?php echo table_row_spacer(3, 10);?>


### PR DESCRIPTION
`text_output` is used around this content in the `sim_missions_all` view but not the `sim_missions_one` view. This inconsistency is frustrating for people who have mission posts more than a paragraph in length.