### PR TITLE
Fix bug with location.view.output on non-_base

### DIFF
--- a/nova/modules/core/helpers/Nova_extension_helper.php
+++ b/nova/modules/core/helpers/Nova_extension_helper.php
@@ -144,7 +144,7 @@ class Nova_extension_container implements ArrayAccess {
 			else
 			{
 				$output = $ci->load->view($location, $data, true);
-				$ci->event->fire(['location', 'view', $obj->sec, $obj->view, 'output'], [
+				$ci->event->fire(['location', 'view', 'output', $obj->sec, $obj->view], [
 					'data' => &$data,
 					'output' => &$output
 				]);


### PR DESCRIPTION
The wrong order here is inconsistent, collides with documentation, and should be fixed so as not to create a headache for extension writers. If this isn't patched, it will require people to write these listeners with two different segment orders for the same action.